### PR TITLE
WIP: Read PDF form fields as utf8

### DIFF
--- a/lib/nguyen/pdf.rb
+++ b/lib/nguyen/pdf.rb
@@ -14,13 +14,13 @@ module Nguyen
 
     protected
 
-      def read_fields
-        field_output = @pdftk.call_pdftk %Q("#{path}"), 'dump_data_fields'
-        @fields = field_output.split(/^---\n/).map do |field_text|
-          if field_text =~ /^FieldName: (\w+)$/
-            $1
-          end
-        end.compact.uniq
-      end
+    def read_fields
+      field_output = @pdftk.call_pdftk path, 'dump_data_fields_utf8'
+      @fields = field_output.split("\n").map do |field_text|
+        if field_text =~ /^FieldName: (.+)$/
+          $1
+        end
+      end.compact.uniq
+    end
   end
 end


### PR DESCRIPTION
Capturing field name with `\w` fails with utf8. 
`dump_data_fields_utf8` is the right method to dump fields in utf8
And some styling change.