### PR TITLE
Add ability to pass xfdf or fdf xml string to pdf wrapper fill_form

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ pdftk.fill_form('/path/to/form.pdf', 'myform.pdf', fdf)
 # with xfdf
 xfdf = Nguyen::Xfdf.new(foo: 'bar')
 pdftk.fill_form('/path/to/form.pdf', 'myform.pdf', xfdf)
+
+# will work with xfdf or fdf xml string directly as well
+xfdf_string = <<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<xfdf xmlns="http://ns.adobe.com/xfdf/" xml:space="preserve"><fields><field name="foo"><value>bar</value></field></fields></xfdf>
+XML
+# or xfdf_string = Nguyen::Xfdf.new(foo: 'bar').to_xfdf
+pdftk.fill_form('/path/to/form', 'myform.pdf', xfdf_string)
 ```
 
 ## INSTALL:

--- a/lib/nguyen/fdf.rb
+++ b/lib/nguyen/fdf.rb
@@ -37,7 +37,7 @@ module Nguyen
     
     # write fdf content to path
     def save_to(path)
-      (File.open(path, 'w') << to_fdf).close
+      File.write(path, to_fdf)
     end
     
     protected

--- a/lib/nguyen/pdftk_wrapper.rb
+++ b/lib/nguyen/pdftk_wrapper.rb
@@ -14,11 +14,11 @@ module Nguyen
       @options = options
     end
 
-    # pdftk.fill_form '/path/to/form.pdf', '/path/to/destination.pdf', xfdf_or_fdf_object
-    def fill_form(template, destination, form_data_format)
+    # pdftk.fill_form '/path/to/form.pdf', '/path/to/destination.pdf', xfdf_or_fdf_object or xfdf_or_fdf_string
+    def fill_form(template, destination, form_data)
       tmp = Tempfile.new('pdf_forms-fdf')
       tmp.close
-      form_data_format.save_to tmp.path
+      form_data.respond_to?(:save_to) ? form_data.save_to(tmp.path) : File.write(tmp.path, form_data)
       command = pdftk_command %Q("#{template}"), 'fill_form', %Q("#{tmp.path}"), 'output', destination, add_options(tmp.path)
       output = %x{#{command}}
       unless File.readable?(destination) && File.size(destination) > 0

--- a/lib/nguyen/xfdf.rb
+++ b/lib/nguyen/xfdf.rb
@@ -37,7 +37,7 @@ module Nguyen
 
     # write fdf content to path
     def save_to(path)
-      (File.open(path, 'w') << to_xfdf).close
+      File.write(path, to_xfdf)
     end
 
   end

--- a/test/pdftk_wrapper_test.rb
+++ b/test/pdftk_wrapper_test.rb
@@ -33,7 +33,7 @@ describe Nguyen::PdftkWrapper do
       end
     end
 
-    describe 'input file xfdf string' do
+    describe 'input file is xfdf xml string' do
       let(:xfdf) { Nguyen::Xfdf.new(quote_of_the_day: 'I love you').to_xfdf }
 
       it 'fills the PDF' do

--- a/test/pdftk_wrapper_test.rb
+++ b/test/pdftk_wrapper_test.rb
@@ -27,9 +27,19 @@ describe Nguyen::PdftkWrapper do
       let(:xfdf) { Nguyen::Xfdf.new(quote_of_the_day: 'I love you') }
 
       it 'fills the PDF' do
-       pdftk.fill_form('test/fixtures/form.pdf', 'output.pdf', xfdf)
-       assert File.size('output.pdf') > 0
-       FileUtils.rm('output.pdf')
+        pdftk.fill_form('test/fixtures/form.pdf', 'output.pdf', xfdf)
+        assert File.size('output.pdf') > 0
+        FileUtils.rm('output.pdf')
+      end
+    end
+
+    describe 'input file xfdf string' do
+      let(:xfdf) { Nguyen::Xfdf.new(quote_of_the_day: 'I love you').to_xfdf }
+
+      it 'fills the PDF' do
+        pdftk.fill_form('test/fixtures/form.pdf', 'output.pdf', xfdf)
+        assert File.size('output.pdf') > 0
+        FileUtils.rm('output.pdf')
       end
     end
   end


### PR DESCRIPTION
Sometimes we get xfdf or fdf xml string directly from client side instead of a hash. This PR tries to make the PdftkWrapper#fill_form to work with direct xml string as well instead of xfdf or fdf class object. Added tests as well and updated the README